### PR TITLE
owlonly renamed to owl-only inline with naming conventions.

### DIFF
--- a/src/tawny/owl.clj
+++ b/src/tawny/owl.clj
@@ -1221,7 +1221,7 @@ value for each frame."
 (def ! owl-not)
 
 ;; "long cuts" for consistency with some
-(def owlonly only)
+(def owl-only only)
 
 
 ;; restrictions! name clash -- we can do nothing about this, so accept the

--- a/src/tawny/render.clj
+++ b/src/tawny/render.clj
@@ -388,7 +388,7 @@ infer. For example, use data-some or object-some, rather than owl-some." }
 (defmethod form OWLObjectAllValuesFrom [a]
   (list
    (exp
-    owlonly
+    only
     object-only)
         (form (.getProperty a))
         (form (.getFiller a))))
@@ -476,7 +476,7 @@ infer. For example, use data-some or object-some, rather than owl-some." }
 
 (defmethod form org.semanticweb.owlapi.model.OWLDataAllValuesFrom [a]
   (list
-   (exp owlonly data-only)
+   (exp only data-only)
         (form (.getProperty a))
         (form (.getFiller a))))
 


### PR DESCRIPTION
Simple "only" used in render.
