### PR TITLE
Don't use obsoleted function

### DIFF
--- a/emacs/tawny-mode.el
+++ b/emacs/tawny-mode.el
@@ -193,7 +193,7 @@
     (nrepl-request:eval form
                        (cider-popup-eval-out-handler doc-buffer)
                        (cider-current-connection)
-                       (nrepl-current-tooling-session)
+                       (cider-current-tooling-session)
                        (cider-current-ns))))
 
 (defun tawny-de-escape (string)


### PR DESCRIPTION
nrepl-current-tooling-session is no longer available and
cider-current-tooling-session should be used.

See also
- https://github.com/clojure-emacs/cider/commit/705133f2bdca33cb5bc6e0a5b4861965e0883ee4