### PR TITLE
Correct keywords and symbols in "Getting Started" docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,8 +131,8 @@ Properties can be created in a similar manner to classes, using the
 example, demonstrates several of these frames:
 
     (defoproperty hasBase
-      :subpropertyof hasIngredient
-      :characteristics functional
+      :super hasIngredient
+      :characteristic :functional
       :range PizzaBase
       :domain Pizza
       )
@@ -155,9 +155,9 @@ defined within it as inverses. For example, `hasIngredient` and
 
     (as-inverse
      (defoproperty hasIngredient
-       :characteristics transitive)
+       :characteristic :transitive)
      (defoproperty isIngredientOf
-       :characteristics transitive
+       :characteristic :transitive
        ))
 
 Likewise, it is possible to add a shared superclass and disjoint statements to


### PR DESCRIPTION
@phillord: If you like, I can submit pull requests to correct the documentation as I see 'em. These changes seem to fix the "Getting Started" trouble I had (#63).

:subproperty -> :super
functional -> :functional
:characterstics -> :characteristic
transitive -> :transitive