### PR TITLE
Showing anonymous ontologies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject uk.org.russet/tawny-owl "2.0.1-SNAPSHOT"
   :description "tawny-owl enables building OWL ontologies in a programmatic environment."
   :url "http://www.russet.org.uk/blog/tawny-owl"
-  :repositories [["maven" "http://repo1.maven.org/maven2"]]
+  :repositories [["maven" "https://repo1.maven.org/maven2"]]
 
   :scm {:url "https://github.com/phillord/tawny-owl.git"
         :name "git"}

--- a/src/tawny/owl.clj
+++ b/src/tawny/owl.clj
@@ -174,16 +174,16 @@ string; use 'iri-for-name' to perform ontology specific expansion"
 ;; Extension of ~p/as-iri~ to ~OWLOntology~ is slightly questionable, since an
 ;; Ontology is identified *not* by an IRI but the combination of an IRI and
 ;; version IRI.
+;; Also note that ~p/as-iri~ returns nil for anonymous ontologies.
 
 ;; #+begin_src clojure
 (extend-type
     OWLOntology
   p/IRIable
   (p/as-iri [entity]
-    (-> entity
-        .getOntologyID
-        .getOntologyIRI
-        .get)))
+    (let [o-iri (-> entity .getOntologyID .getOntologyIRI)]
+      (if (.isPresent o-iri)
+        (.get o-iri)))))
 
 (defn iriable?
   "Returns true iff entity is an IRIable."

--- a/src/tawny/owl_print.clj
+++ b/src/tawny/owl_print.clj
@@ -235,9 +235,9 @@
     "#[%s 0x%x %s %s:%s]"
     (name-for-class o)
     (System/identityHashCode o)
-    (shorten-iri
-     (.get
-      (.getOntologyIRI
-       (.getOntologyID o))))
+    (let [o-iri (-> o .getOntologyID .getOntologyIRI)]
+      (if (.isPresent o-iri)
+        (shorten-iri (.get o-iri))
+        ""))
     (.getAxiomCount o)
     (.getLogicalAxiomCount o))))


### PR DESCRIPTION
Hi!

I made a few adjustments to the ontology printers – specifically, I added a check for "anonymous" ontologies (w/o ontology URIs) that will make the printer output a blank string instead of crashing ;)

(Also, leiningen was complaining about non-HTTPs URI for the repo – I changed that to "https" in `project.clj`).