### PR TITLE
Upgrade to OWLAPI 5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
 
   :dependencies [
                  ;; owl API
-                 [net.sourceforge.owlapi/owlapi-distribution "4.5.26"]
+                 [net.sourceforge.owlapi/owlapi-distribution "5.5.1"]
 
                  ;; clojure
                  [org.clojure/clojure "1.11.1"]

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,10 @@
                  ;;:init (require 'tawny.repl)
                  }
 
+  :managed-dependencies [[com.google.guava/guava "33.0.0-jre"]
+                         [com.google.code.findbugs/jsr305 "3.0.2"]
+                         [org.slf4j/slf4j-api "2.0.11"]]
+
   :test-selectors {:slow :slow
                    :commit (complement :slow)}
 
@@ -35,18 +39,12 @@
                  [org.clojure/core.logic "1.0.1"]
 
                  ;; reasoners
-                 [org.semanticweb.elk/elk-owlapi "0.4.3"]
-                 [net.sourceforge.owlapi/org.semanticweb.hermit "1.3.8.413"]
-                 [net.sourceforge.owlapi/jfact "4.0.2"
+                 [org.semanticweb.elk/elk-owlapi "0.6.0"]
+                 [net.sourceforge.owlapi/org.semanticweb.hermit "1.4.5.519"]
+                 [net.sourceforge.owlapi/jfact "5.0.3"
                   :exclusions [net.sourceforge.owlapi/owlapi-apibinding]]
 
-                 ;; I have to explicitly include several dependencies
-                 ;; specifically so I can switch the logging off. How does
-                 ;; this make sense?
-
-                 ;; Shut up ELK
-                 [org.apache.logging.log4j/log4j "2.21.1" :extension "pom"]
-                 ;; Shut up OWL API
+                 ;; Shut up OWL API and ELK
                  [org.slf4j/slf4j-nop "2.0.9"]
 
                  ;; identitas
@@ -56,6 +54,9 @@
   ;; dependency adds dev-resources to the path which I need for testing.
   :profiles
   {
+   :1.12
+   [:base
+    {:dependencies [[org.clojure/clojure "1.12.4"]]}]
    :1.10
    [:base
     {:dependencies [[org.clojure/clojure "1.10.0"]]}]

--- a/project.clj
+++ b/project.clj
@@ -35,8 +35,8 @@
                  [net.sourceforge.owlapi/owlapi-distribution "5.5.1"]
 
                  ;; clojure
-                 [org.clojure/clojure "1.11.1"]
-                 [org.clojure/core.logic "1.0.1"]
+                 [org.clojure/clojure "1.12.4"]
+                 [org.clojure/core.logic "1.1.1"]
 
                  ;; reasoners
                  [org.semanticweb.elk/elk-owlapi "0.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                  [org.clojure/core.logic "1.1.1"]
 
                  ;; reasoners
-                 [org.semanticweb.elk/elk-owlapi "0.6.0"]
+                 [io.github.liveontologies/elk-owlapi "0.6.0"]
                  [net.sourceforge.owlapi/org.semanticweb.hermit "1.4.5.519"]
                  [net.sourceforge.owlapi/jfact "5.0.3"
                   :exclusions [net.sourceforge.owlapi/owlapi-apibinding]]

--- a/src/tawny/owl.clj
+++ b/src/tawny/owl.clj
@@ -183,7 +183,7 @@ string; use 'iri-for-name' to perform ontology specific expansion"
     (-> entity
         .getOntologyID
         .getOntologyIRI
-        .get)))
+        (.orElse nil))))
 
 (defn iriable?
   "Returns true iff entity is an IRIable."
@@ -722,7 +722,7 @@ or the current-ontology"
 
 This is likely to become a property of the ontology at a later date, but at
 the moment it is very simple."
-  [o name]
+  ^IRI [o name]
   (if-let [iri-gen (:iri-gen (deref (ontology-options o)))]
     (iri-gen o name)
     (iri (str (ontology-iri-with-terminator o) name))))
@@ -884,7 +884,7 @@ converting it from an IRI if necessary."
    property
    (t/iri? property)
    (.getOWLAnnotationProperty
-    (owl-data-factory) property)
+    (owl-data-factory) ^IRI property)
    :default
    (throw (IllegalArgumentException.
            (format "Expecting an OWL annotation property: %s" property)))))
@@ -1076,7 +1076,7 @@ add-sub-annotation functionality."
   [o property]
   (.getOWLAnnotationProperty
    (owl-data-factory)
-   (iri-for-name o property)))
+   ^IRI (iri-for-name o property)))
 ;; #+end_src
 
 ;; * Ontology defentity
@@ -1279,7 +1279,7 @@ This calls the relevant hooks, so is better than direct use of the OWL API. "
   [^OWLOntology o ^String p]
   (if p
     (.setDefaultPrefix
-     (.asPrefixOWLOntologyFormat
+     (.asPrefixOWLDocumentFormat
       (.getOntologyFormat
        (owl-ontology-manager) o))
      p)))
@@ -1489,7 +1489,7 @@ is given."
   ;; my assumption here is that there will only ever be one prefix for a given
   ;; ontology. If not, it's all going to go wrong.
   (.getDefaultPrefix
-   (.asPrefixOWLOntologyFormat
+   (.asPrefixOWLDocumentFormat
     (.getOntologyFormat (owl-ontology-manager)
                         o))))
 
@@ -1529,13 +1529,13 @@ If no ontology is given, use the current-ontology"
                (str "## This file was created by Tawny-OWL\n"
                     "## It should not be edited by hand\n" )
                :else ""))]
-     (when (.isPrefixOWLOntologyFormat format)
+     (when (.isPrefixOWLDocumentFormat format)
        (doseq [ont (.getOntologies (owl-ontology-manager))
                :when (get-prefix ont)]
          (.setPrefix
-          (.asPrefixOWLOntologyFormat format) (get-prefix ont)
+          (.asPrefixOWLDocumentFormat format) (get-prefix ont)
           (str (p/as-iri ont) "#")))
-       (.setPrefix (.asPrefixOWLOntologyFormat format) (get-prefix o)
+       (.setPrefix (.asPrefixOWLDocumentFormat format) (get-prefix o)
                    (ontology-iri-with-terminator o)))
      (.print file-writer prepend)
      (.flush file-writer)
@@ -1658,7 +1658,7 @@ or throw an exception if it cannot be converted."
      (t/obj-prop-exp? prop)
      prop
      (t/iri? prop)
-     (.getOWLObjectProperty (owl-data-factory) prop)
+     (.getOWLObjectProperty (owl-data-factory) ^IRI prop)
      :default
      (throw (IllegalArgumentException.
              (str "Expecting an object property. Got: " prop))))))
@@ -1677,7 +1677,7 @@ else if clz is a OWLClassExpression add that."
      (t/class-exp? clz)
      clz
      (t/iri? clz)
-     (.getOWLClass (owl-data-factory) clz)
+     (.getOWLClass (owl-data-factory) ^IRI clz)
      (fn? clz)
      (try
        (ensure-class (clz))
@@ -1696,7 +1696,7 @@ converting it from a string or IRI if necessary."
      property
      (t/iri? property)
      (.getOWLDataProperty
-      (owl-data-factory) property)
+      (owl-data-factory) ^IRI property)
     :default
      (throw (IllegalArgumentException.
              (format "Expecting an OWL data property: %s" property))))))
@@ -1764,7 +1764,7 @@ interpret this as a string and create a new OWLIndividual."
       individual
       (t/iri? individual)
       (.getOWLNamedIndividual (owl-data-factory)
-                              individual)
+                              ^IRI individual)
       :default
       (throw (IllegalArgumentException.
               (str "Expecting an Individual. Got: " individual))))))
@@ -1845,6 +1845,7 @@ opposite of this."
    o
    (.getOWLDisjointClassesAxiom
     (owl-data-factory)
+    ^java.util.Collection
     (hash-set (ensure-class name)
               (ensure-class disjoint))
     (p/as-annotations disjoint))))
@@ -1860,6 +1861,7 @@ opposite of this."
                 (.getOWLDisjointUnionAxiom
                  (owl-data-factory)
                  (ensure-class clazz)
+                 ^java.util.Collection
                  (set
                   (map
                    ensure-class
@@ -2597,6 +2599,7 @@ All arguments must of an instance of OWLClassExpression"
      o
      (.getOWLDisjointClassesAxiom
       (owl-data-factory)
+      ^java.util.Collection
       (set classlist)
       (union-annotations list)))))
 
@@ -2946,7 +2949,7 @@ expressions."
   (let [^OWLClass clz (ensure-class name)]
     ;; general Class expressions return empty
     (if (t/owl-class? clz)
-      (EntitySearcher/getSuperClasses clz o)
+      (util/stream-seq (EntitySearcher/getSuperClasses clz o))
       ())))
 
 (defno superclasses
@@ -2971,7 +2974,7 @@ direct or indirect superclass of itself."
   [^OWLOntology o name]
   (let [clz (ensure-class name)]
     (if (t/owl-class? clz)
-      (EntitySearcher/getSubClasses clz o) ())))
+      (util/stream-seq (EntitySearcher/getSubClasses clz o)) ())))
 
 (defno subclasses
   "Return all subclasses of class."
@@ -2995,13 +2998,16 @@ direct or indirect superclass of itself."
   (let [type (guess-type-args a b)]
     (cond
      (isa? type ::class)
-     (contains?
+     (util/stream-contains?
       (EntitySearcher/getDisjointClasses ^OWLClass a o)
       b)
      ;; works for either data or object properties
      (isa? type ::property)
-     (contains?
-      (EntitySearcher/getDisjointProperties ^OWLProperty a o)
+     (util/stream-contains?
+      (cond
+       (t/obj-prop-exp? a) (EntitySearcher/getDisjointProperties ^OWLObjectPropertyExpression a o)
+       (t/data-prop? a) (EntitySearcher/getDisjointProperties ^OWLDataProperty a o)
+       :else (EntitySearcher/getDisjointProperties ^OWLAnnotationProperty a o))
       b)
      :default
      (throw
@@ -3014,11 +3020,14 @@ direct or indirect superclass of itself."
   (let [type (guess-type-args a b)]
     (cond
      (isa? type ::class)
-     (contains?
+     (util/stream-contains?
       (EntitySearcher/getEquivalentClasses ^OWLClass a o) b)
      (isa? type ::property)
-     (contains?
-      (EntitySearcher/getEquivalentProperties ^OWLProperty a o)
+     (util/stream-contains?
+      (cond
+       (t/obj-prop-exp? a) (EntitySearcher/getEquivalentProperties ^OWLObjectPropertyExpression a o)
+       (t/data-prop? a) (EntitySearcher/getEquivalentProperties ^OWLDataProperty a o)
+       :else (EntitySearcher/getEquivalentProperties ^OWLAnnotationProperty a o))
       b)
      :default
      (throw
@@ -3028,14 +3037,18 @@ direct or indirect superclass of itself."
 (defno inverse?
   "Returns t iff properties are asserted to be inverse"
   [^OWLOntology o ^OWLObjectProperty p1 ^OWLObjectProperty p2]
-  (contains?
+  (util/stream-contains?
    (EntitySearcher/getInverses p1 o) p2))
 
 (defno direct-superproperties
   "Return all direct superproperties of property."
   [^OWLOntology o property]
-  (EntitySearcher/getSuperProperties
-   (ensure-property property) o))
+  (let [prop (ensure-property property)]
+    (util/stream-seq
+     (cond
+      (t/obj-prop-exp? prop) (EntitySearcher/getSuperProperties ^OWLObjectPropertyExpression prop o)
+      (t/data-prop? prop) (EntitySearcher/getSuperProperties ^OWLDataProperty prop o)
+      :else (EntitySearcher/getSuperProperties ^OWLAnnotationProperty prop o)))))
 
 (defno superproperties
   "Return all superproperties of a property."
@@ -3055,8 +3068,12 @@ direct or indirect superclass of itself."
   "Returns all direct subproperties of property."
   [^OWLOntology o
    property]
-  (EntitySearcher/getSubProperties
-   (ensure-property property) o))
+  (let [prop (ensure-property property)]
+    (util/stream-seq
+     (cond
+      (t/obj-prop-exp? prop) (EntitySearcher/getSubProperties ^OWLObjectPropertyExpression prop o)
+      (t/data-prop? prop) (EntitySearcher/getSubProperties ^OWLDataProperty prop o)
+      :else (EntitySearcher/getSubProperties ^OWLAnnotationProperty prop o)))))
 
 (defno subproperties
   "Returns all subproperties of property."
@@ -3077,7 +3094,7 @@ direct or indirect superclass of itself."
   [^OWLOntology o name]
   (let [clz (ensure-class name)]
     (if (t/owl-class? clz)
-      (EntitySearcher/getIndividuals clz o) ())))
+      (util/stream-seq (EntitySearcher/getIndividuals clz o)) ())))
 ;; #+end_src
 
 ;; * Test Support

--- a/src/tawny/owl_data.clj
+++ b/src/tawny/owl_data.clj
@@ -205,7 +205,7 @@ which is an OWLDatatype object.
 
 (defnb2 add-datatype-equivalent
   "Adds a datatype equivalent axiom"
-  [o datatype equivalent]
+  [o ^OWLDatatype datatype equivalent]
   (add-axiom
    o (.getOWLDatatypeDefinitionAxiom
       (owl-data-factory) datatype
@@ -231,7 +231,7 @@ which is an OWLDatatype object.
          (owl-data-factory)
          (if (string? name)
            (iri-for-name o name)
-           name))]
+           ^IRI name))]
     (add-axiom o
      (.getOWLDeclarationAxiom (owl-data-factory) datatype))
     (add-a-name-annotation o datatype name)

--- a/src/tawny/owl_print.clj
+++ b/src/tawny/owl_print.clj
@@ -23,13 +23,15 @@
         ann
         (EntitySearcher/getAnnotationObjects
          iri
-         (.getOntologies
-          (tawny.owl/owl-ontology-manager))
+         (.stream
+          ^java.util.Collection
+          (.getOntologies
+           (tawny.owl/owl-ontology-manager)))
          tawny-name-property)
 
         ^org.semanticweb.owlapi.model.OWLAnnotation
         first-ann
-        (first ann)
+        (.. ann findFirst (orElse nil))
 
         ^org.semanticweb.owlapi.model.OWLAnnotationValue
         val
@@ -236,8 +238,9 @@
     (name-for-class o)
     (System/identityHashCode o)
     (shorten-iri
-     (.get
+     (.orElse
       (.getOntologyIRI
-       (.getOntologyID o))))
+       (.getOntologyID o))
+      nil))
     (.getAxiomCount o)
     (.getLogicalAxiomCount o))))

--- a/src/tawny/owl_self.clj
+++ b/src/tawny/owl_self.clj
@@ -29,7 +29,7 @@
    (.getOWLLiteral (owl-data-factory) literal "en")))
 
 (defn- tawny-annotation-property
-  [iri]
+  [^IRI iri]
   (.getOWLAnnotationProperty (owl-data-factory) iri))
 
 (def ^{:private true} tawny-base-url

--- a/src/tawny/pattern.clj
+++ b/src/tawny/pattern.clj
@@ -257,8 +257,9 @@ with other entities that are annotated to the same anonymous individual.")
    (fn [^OWLAnnotation anon]
      (= (.getProperty anon)
         inpattern))
-   (EntitySearcher/getAnnotations
-    (p/as-entity entity) o)))
+   (u/stream-seq
+    (EntitySearcher/getAnnotations
+     (p/as-entity entity) o))))
 
 (o/defno which-pattern
   "Returns the OWLAnonymousIndividual(s) describing the pattern(s)
@@ -352,7 +353,7 @@ to explicitly name the object property."
          (fn [^OWLAnnotation anon]
            (= (.getProperty anon)
               facetvalue))
-         (EntitySearcher/getAnnotations cls o)))]
+         (u/stream-seq (EntitySearcher/getAnnotations cls o))))]
     (if (= 1 (count prop))
       ;; there should be only one, and we have no good basis to pick if there
       ;; are more than one.

--- a/src/tawny/read.clj
+++ b/src/tawny/read.clj
@@ -19,7 +19,8 @@
     ^{:doc "Read external OWL files and use them in tawny"
       :author "Phillip Lord"}
   tawny.read
-  (:require [tawny owl util protocol]
+  (:require [tawny owl protocol]
+            [tawny.util :as u]
             [clojure.string :only replace]
             [tawny.type :as t])
   (:refer-clojure :exclude [read])
@@ -30,7 +31,7 @@
    (org.semanticweb.owlapi.model
     OWLAnnotation OWLLiteral
     IRI OWLNamedObject OWLOntologyID
-    OWLOntology OWLEntity)
+    OWLOntology OWLEntity OWLOntologyIRIMapper)
    (org.semanticweb.owlapi.search EntitySearcher)))
 
 (def ^:dynamic *noisy-intern* nil)
@@ -63,7 +64,7 @@ starts-with. Use this partially applied with a filter for 'read'."
    #(some-> ^OWLAnnotation %
         (.getProperty)
         (.isLabel))
-   (EntitySearcher/getAnnotations e o)))
+   (u/stream-seq (EntitySearcher/getAnnotations e o))))
 
 (defn label-transform
   "Get text from label annotation"
@@ -189,12 +190,12 @@ iri-mapper and resource-iri-mapper.
         (do
           (tawny.owl/remove-ontology-maybe ontologyid)
           (when mapper
-            (.addIRIMapper
-             (tawny.owl/owl-ontology-manager)
-             mapper))
+            (.add
+             (.getIRIMappers (tawny.owl/owl-ontology-manager))
+             ^OWLOntologyIRIMapper mapper))
           (try
             ;; use the with types thing!
-            (tawny.util/with-types
+            (u/with-types
               [location [java.io.File java.io.InputStream
                          IRI org.semanticweb.owlapi.io.OWLOntologyDocumentSource]]
               (.loadOntologyFromOntologyDocument
@@ -202,15 +203,15 @@ iri-mapper and resource-iri-mapper.
                location))
             (finally
               (when mapper
-                (.removeIRIMapper
-                 (tawny.owl/owl-ontology-manager)
-                 mapper)))))]
+                (.remove
+                 (.getIRIMappers (tawny.owl/owl-ontology-manager))
+                 ^OWLOntologyIRIMapper mapper)))))]
     (when prefix
       (let [format (.getOntologyFormat (tawny.owl/owl-ontology-manager)
                                        owlontology)]
-        (if (.isPrefixOWLOntologyFormat format)
+        (if (.isPrefixOWLDocumentFormat format)
           (.setDefaultPrefix
-           (.asPrefixOWLOntologyFormat format)
+           (.asPrefixOWLDocumentFormat format)
            prefix)
           (throw (IllegalArgumentException.
                   "Attempt to provide a prefix to an ontology that is not using a prefix format")))))

--- a/src/tawny/reasoner.clj
+++ b/src/tawny/reasoner.clj
@@ -32,7 +32,7 @@
       JProgressBar
       WindowConstants)
    (java.awt GraphicsEnvironment)
-   (org.semanticweb.owlapi.model OWLOntology)
+   (org.semanticweb.owlapi.model OWLOntology OWLClassExpression)
    (org.semanticweb.owlapi.reasoner
     OWLReasoner OWLReasonerFactory
     NodeSet)
@@ -295,7 +295,7 @@ set and does not return top or bottom."
   (no-top-bottom
    (entities
     (.getSuperClasses (reasoner ontology)
-                      (#'tawny.owl/ensure-class name)
+                      ^OWLClassExpression (#'tawny.owl/ensure-class name)
                       false))))
 
 ;; move this to using isuperclasses
@@ -314,7 +314,7 @@ Returns a clojure set, and does not return top or bottom."
   (no-top-bottom
    (entities
     (.getSubClasses (reasoner o)
-                    (#'tawny.owl/ensure-class name)
+                    ^OWLClassExpression (#'tawny.owl/ensure-class name)
                     false))))
 
 (defno isubclass?
@@ -346,4 +346,4 @@ may include top or bottom."
   [ontology class]
   (entities
    (.getInstances (reasoner ontology)
-                  class false)))
+                  ^OWLClassExpression class false)))

--- a/src/tawny/reasoner.clj
+++ b/src/tawny/reasoner.clj
@@ -37,20 +37,13 @@
     OWLReasoner OWLReasonerFactory
     NodeSet)
    (org.semanticweb.elk.owlapi ElkReasonerFactory)
-   (org.apache.log4j
-    Level
-    Logger)
    (org.semanticweb.owlapi.reasoner SimpleConfiguration)
    (org.semanticweb.HermiT Reasoner)))
 
 (defn- reasoner-factory-1 [reasoner-keyword]
   (reasoner-keyword
    {:elk
-    (do
-      ;; ELK is noisy, so shut it up
-      (-> (Logger/getLogger "org.semanticweb.elk")
-          (.setLevel Level/ERROR));
-      (ElkReasonerFactory.))
+    (ElkReasonerFactory.)
     :hermit (org.semanticweb.HermiT.Reasoner$ReasonerFactory.)
     :jfact (uk.ac.manchester.cs.jfact.JFactFactory.)
     :nil nil}))

--- a/src/tawny/render.clj
+++ b/src/tawny/render.clj
@@ -20,7 +20,7 @@
   tawny.render
   (:require [tawny.owl :as owl]
             [tawny.lookup]
-            [tawny.util]
+            [tawny.util :as u]
             [clojure.set])
   (:import
            (java.util Collection Set)
@@ -333,9 +333,9 @@
        (owl/owl-ontology-manager))))
 
 (defn- setmap
-  "Apply f to list c, union the results."
+  "Apply f to each element of c, collecting and unioning all results."
   [f c]
-  (apply clojure.set/union (map f c)))
+  (into #{} (mapcat #(u/stream-seq (f %))) c))
 
 (declare form)
 
@@ -387,15 +387,15 @@
        (list (form o options)))
 
      (list :iri
-           (.. o getOntologyID getOntologyIRI orNull toString))
+           (str (.. o getOntologyID getOntologyIRI (orElse nil))))
 
-     (let [viri (.. o getOntologyID getVersionIRI orNull)]
+     (let [viri (.. o getOntologyID getVersionIRI (orElse nil))]
        (when viri
          (list :viri (str viri))))
      ;; what to do about noname? guess we pass it in as an option
      ;; or we could check existing options
      (when-let [f (.getOntologyFormat (tawny.owl/owl-ontology-manager) o)]
-       (when (.isPrefixOWLOntologyFormat f)
+       (when (.isPrefixOWLDocumentFormat f)
          (when-let [pre (tawny.owl/get-prefix o)]
            (list :prefix pre))))
      ;; imports
@@ -414,10 +414,10 @@
 
 (defmethod as-form-int OWLClass
   [^OWLClass c options]
-  (let [ont (ontologies options)
-        super (EntitySearcher/getSuperClasses c ont)
-        equiv (EntitySearcher/getEquivalentClasses c ont)
-        disjoint (EntitySearcher/getDisjointClasses c ont)
+  (let [^java.util.Collection ont (ontologies options)
+        super (u/stream-set (EntitySearcher/getSuperClasses c (.stream ont)))
+        equiv (u/stream-set (EntitySearcher/getEquivalentClasses c (.stream ont)))
+        disjoint (u/stream-set (EntitySearcher/getDisjointClasses c (.stream ont)))
         annotation
         (setmap
          (fn [^OWLOntology o]
@@ -455,11 +455,11 @@
 
 (defmethod as-form-int OWLObjectProperty
   [^OWLObjectProperty p options]
-  (let [ont (ontologies options)
-        domain (EntitySearcher/getDomains p ont)
-        range (EntitySearcher/getRanges p ont)
-        inverseof (EntitySearcher/getInverses p ont)
-        superprop (EntitySearcher/getSuperProperties p ont)
+  (let [^java.util.Collection ont (ontologies options)
+        domain (u/stream-set (EntitySearcher/getDomains p (.stream ont)))
+        range (u/stream-set (EntitySearcher/getRanges p (.stream ont)))
+        inverseof (u/stream-set (EntitySearcher/getInverses p (.stream ont)))
+        superprop (u/stream-set (EntitySearcher/getSuperProperties p (.stream ont)))
         subchainaxioms
         ;; only the ones associated with this property
         (filter
@@ -482,25 +482,25 @@
         (filter identity
                 (list
                  (and
-                  (EntitySearcher/isTransitive p ont)
+                  (EntitySearcher/isTransitive p (.stream ont))
                   :transitive)
                  (and
-                  (EntitySearcher/isFunctional p ont)
+                  (EntitySearcher/isFunctional p (.stream ont))
                   :functional)
                  (and
-                  (EntitySearcher/isInverseFunctional p ont)
+                  (EntitySearcher/isInverseFunctional p (.stream ont))
                   :inversefunctional)
                  (and
-                  (EntitySearcher/isSymmetric p ont)
+                  (EntitySearcher/isSymmetric p (.stream ont))
                   :symmetric)
                  (and
-                  (EntitySearcher/isAsymmetric p ont)
+                  (EntitySearcher/isAsymmetric p (.stream ont))
                   :asymmetric)
                  (and
-                  (EntitySearcher/isIrreflexive p ont)
+                  (EntitySearcher/isIrreflexive p (.stream ont))
                   :irreflexive)
                  (and
-                  (EntitySearcher/isReflexive p ont)
+                  (EntitySearcher/isReflexive p (.stream ont))
                   :reflexive)
                  ))
         lst (if (get options :keyword)
@@ -545,8 +545,8 @@
 
 (defmethod as-form-int OWLNamedIndividual
   [^OWLNamedIndividual p options]
-  (let [ont (ontologies options)
-        types (EntitySearcher/getTypes p ont)
+  (let [^java.util.Collection ont (ontologies options)
+        types (u/stream-set (EntitySearcher/getTypes p (.stream ont)))
         same (setmap
               (fn [^OWLOntology o]
                 (EntitySearcher/getSameIndividuals p o)) ont)
@@ -564,28 +564,28 @@
                 (into
                  (sorted-map)
                  (.asMap
-                  (EntitySearcher/getObjectPropertyValues p ont)))]
+                  (EntitySearcher/getObjectPropertyValues p (.stream ont))))]
             (when (seq fs)
               {::type :object-fact :facts fs}))
           (let [fs
                 (into
                  (sorted-map)
                  (.asMap
-                   (EntitySearcher/getDataPropertyValues p ont)))]
+                   (EntitySearcher/getDataPropertyValues p (.stream ont))))]
             (when (seq fs)
               {::type :data-fact :facts fs}))
           (let [fs
                 (into
                  (sorted-map)
                  (.asMap
-                  (EntitySearcher/getNegativeObjectPropertyValues p ont)))]
+                  (EntitySearcher/getNegativeObjectPropertyValues p (.stream ont))))]
             (when (seq fs)
               {::type :object-fact-not :facts fs}))
           (let [fs
                 (into
                  (sorted-map)
                  (.asMap
-                  (EntitySearcher/getNegativeDataPropertyValues p ont)))]
+                  (EntitySearcher/getNegativeDataPropertyValues p (.stream ont))))]
             (when (seq fs)
               {::type :data-fact-not :facts fs}))))
         ind (form p options)
@@ -617,10 +617,10 @@
 
 (defmethod as-form-int OWLDataProperty
   [^OWLDataProperty p options]
-  (let [ont (ontologies options)
-        domain (EntitySearcher/getDomains p ont)
-        range (EntitySearcher/getRanges p ont)
-        superprop (EntitySearcher/getSuperProperties p ont)
+  (let [^java.util.Collection ont (ontologies options)
+        domain (u/stream-set (EntitySearcher/getDomains p (.stream ont)))
+        range (u/stream-set (EntitySearcher/getRanges p (.stream ont)))
+        superprop (u/stream-set (EntitySearcher/getSuperProperties p (.stream ont)))
         annotation
         (setmap
          (fn [^OWLOntology o] (EntitySearcher/getAnnotations p o)) ont)
@@ -628,7 +628,7 @@
         (filter identity
                 (list
                  (and
-                  (EntitySearcher/isFunctional p ont)
+                  (EntitySearcher/isFunctional p (.stream ont))
                   :functional)
                  ))
         prop (form p options)
@@ -657,7 +657,7 @@
 
 (defmethod as-form-int OWLAnnotationProperty
   [^OWLAnnotationProperty p options]
-  (let [ont (ontologies options)
+  (let [^java.util.Collection ont (ontologies options)
         super
         (setmap (fn [^OWLOntology o] (EntitySearcher/getSuperProperties p o)) ont)
         ann

--- a/src/tawny/repl.clj
+++ b/src/tawny/repl.clj
@@ -23,6 +23,7 @@
             [tawny.protocol :as p]
             [tawny.render]
             [tawny.type :as t]
+            [tawny.util :as u]
             [clojure.pprint]
             )
   (:import [java.io StringWriter PrintWriter]
@@ -43,8 +44,9 @@ The documentation is generated over the live object (owlobjects are mutable).
 It includes all labels, comments and a rendered version of the owlobject."
   [^OWLEntity owlobject]
   (let [annotation
-        (org.semanticweb.owlapi.search.EntitySearcher/getAnnotationObjects
-         owlobject (.getOntologies (o/owl-ontology-manager)))
+        (u/stream-seq
+         (org.semanticweb.owlapi.search.EntitySearcher/getAnnotationObjects
+          owlobject (.stream ^java.util.Collection (.getOntologies (o/owl-ontology-manager))) nil))
         label
         (filter
          (fn [^OWLAnnotation a]
@@ -157,7 +159,9 @@ once."
       (println "Finished Loading:"
                (-> event
                    (.getOntologyID)
-                   (.getOntologyIRI))
+                   (.getOntologyIRI)
+                   (.orElse nil)
+                   str)
                (if (.isSuccessful event)
                  "...succeeded"))
       (if-not (.isSuccessful event)
@@ -165,10 +169,10 @@ once."
     (startedLoadingOntology
       [^OWLOntologyLoaderListener$LoadingEvent event]
       (println "Started Loading:"
-               (or (-> event
-                       (.getOntologyID)
-                       (.getOntologyIRI))
-                   "unknown")
+               (-> event
+                   (.getOntologyID)
+                   (.getOntologyIRI)
+                   (.orElse "unknown"))
                " from:"
                (.getDocumentIRI event)))))
 
@@ -208,15 +212,15 @@ to file names. Save ontologies in 'root' or the resources directory."
                 [(-> k
                      (.getOntologyID)
                      (.getOntologyIRI)
-                     (.toString))
+                     (.orElse nil)
+                     str)
                  (let
                      [file-maybe
-                      (-> k
-                          (.getOntologyID)
-                          (.getOntologyIRI)
-                          (.orNull)
-                          (p/as-iri)
-                          (.getFragment))
+                      (when-let [^IRI iri (-> k
+                                              (.getOntologyID)
+                                              (.getOntologyIRI)
+                                              (.orElse nil))]
+                        (.getFragment iri))
                       stem
                       (if file-maybe
                         file-maybe
@@ -276,7 +280,7 @@ to file names. Save ontologies in 'root' or the resources directory."
   ([^org.semanticweb.owlapi.model.OWLOntology o]
      (filter
       (fn [axiom]
-        (tawny.util/on-type
+        (u/on-type
          org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom axiom
          (= (var-get #'tawny.owl/tawny-name-property)
             (.getProperty axiom))))

--- a/src/tawny/util.clj
+++ b/src/tawny/util.clj
@@ -16,9 +16,29 @@
 ;; along with this program.  If not, see http://www.gnu.org/licenses/.
 
 (ns tawny.util
-  (:import [java.io Writer])
+  (:import [java.io Writer]
+           [java.util.stream Stream])
   (:require [clojure.walk]))
 
+
+;;
+;; Java Stream utilities
+;;
+
+(defn stream-seq
+  "Convert a Java Stream to a Clojure lazy sequence."
+  [^Stream s]
+  (iterator-seq (.iterator s)))
+
+(defn stream-set
+  "Convert a Java Stream to a Clojure set."
+  [^Stream s]
+  (into #{} (stream-seq s)))
+
+(defn stream-contains?
+  "Returns true if stream s contains x."
+  [^Stream s x]
+  (some #{x} (stream-seq s)))
 
 ;;
 ;; Utillity functions for improving syntax

--- a/test/tawny/owl_test.clj
+++ b/test/tawny/owl_test.clj
@@ -589,9 +589,8 @@ Assumes that fixture has been run"
    (o/with-probe-entities to
      [c (o/owl-class to "c")
       i (o/individual to "i" :type c)]
-     (contains?
-      (o/direct-instances to c)
-      i))))
+     (some #{i}
+           (o/direct-instances to c)))))
 
 
 (deftest superclasses []
@@ -643,7 +642,7 @@ Assumes that fixture has been run"
    (let [cls (o/owl-class to "cls")
          ind (o/individual to "ind" :type cls)]
      (tawny.util/in?
-      (EntitySearcher/getTypes ind to)
+      (iterator-seq (.iterator (EntitySearcher/getTypes ind to)))
       cls))))
 
 (deftest defindividual []
@@ -815,7 +814,7 @@ Assumes that fixture has been run"
             #(-> %
                  (.getProperty)
                  (.isLabel))
-            (EntitySearcher/getAnnotations b to))))))))))
+            (iterator-seq (.iterator (EntitySearcher/getAnnotations b to))))))))))))
 
 
 (deftest dataproperty
@@ -1024,7 +1023,7 @@ Assumes that fixture has been run"
         i2 (o/individual to "i2")]
      (o/add-different to i1 i2)
      (some #{i2}
-           (EntitySearcher/getDifferentIndividuals i1 to)))))
+           (iterator-seq (.iterator (EntitySearcher/getDifferentIndividuals i1 to)))))))
 
 
 (deftest add-data-super

--- a/test/tawny/query_test.clj
+++ b/test/tawny/query_test.clj
@@ -74,11 +74,11 @@
    (q/data-props to)))
 
 (deftest data-types []
-  (is
-   (do
-     (o/owl-class to "a"  :label "hello")
-     (.isRDFPlainLiteral
-      (first (q/data-types to))))))
+  (let [dt (do (o/owl-class to "a" :label "hello")
+               (first (q/data-types to)))]
+    (is (.isBuiltIn dt))
+    (is (= (.getIRI org.semanticweb.owlapi.vocab.OWL2Datatype/RDF_LANG_STRING)
+           (.getIRI dt)))))
 
 (deftest direct-imports []
   (is-set=
@@ -102,6 +102,7 @@
 
 ;; Core logic additions
 (defn read-sio []
+  (System/setProperty "jdk.xml.totalEntitySizeLimit" "200000")
   (tawny.owl/remove-ontology-maybe
    (org.semanticweb.owlapi.model.OWLOntologyID.
     (tawny.owl/iri "http://semanticscience.org/ontology/sio.owl")))

--- a/test/tawny/render_sio_test.clj
+++ b/test/tawny/render_sio_test.clj
@@ -7,6 +7,7 @@
 )
 
 (defn read-sio []
+  (System/setProperty "jdk.xml.totalEntitySizeLimit" "200000")
   (tawny.owl/remove-ontology-maybe
    (org.semanticweb.owlapi.model.OWLOntologyID.
     (tawny.owl/iri "http://semanticscience.org/ontology/sio.owl")))


### PR DESCRIPTION
This updates OWLAPI 4.5.26 → 5.5.1, along with the reasoners:
 * ELK 0.4.3 → 0.6.0
 * Hermit 1.3.8.413 → 1.4.5.519
 * JFact 4.0.2 → 5.0.3

## OWLAPI Updates
Updating is described in OWLAPI on the [4→5 Migration page](https://github.com/owlcs/owlapi/wiki/Migrate-to-version-5). The main changes are:
 * Many operations that accepted or returned [Sets](https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/Set.html) now use Java [Streams](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/util/stream/Stream.html) instead.
 * New method overloads now require type hinting to resolve the correct methods.
 * Method renaming. e.g.:
   * `asPrefixOWLOntologyFormat` → `asPrefixOWLDocumentFormat`
   * `ontologyManager.addIRIMapping(mapper)` → `ontologyManager.getIRIMappers().add(mapper)`
 * Moved from [Guava Optional](https://guava.dev/releases/19.0/api/docs/com/google/common/base/Optional.html) results to [Java Optional](https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/Optional.html)
 * Literals with a language tag changed `OWLDatatype`: `rdf:PlainLiteral` → `rdf:langString`. So `OWLDatatype.isRDFPlainLiteral()` is now `false` for these objects.

## Reasoner Updates
 * OWLAPI uses slf4j, and uses slf4j-nop to keep it silent. ELK 0.4.3 logged via log4j directly, so this needed a log4j setting to keep it quiet. ELK 0.6.0 now uses slf4j, so slf4j-nop is sufficient.
 * The `dev-resources/sio.owl` file used in testing has too many entities for JAXP to parse by default. The limits were increased to allow loading.