### PR TITLE
Added managed-dependencies for the stale dependencies from elk-owlapi

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,9 @@
 
   :managed-dependencies [[com.google.guava/guava "33.0.0-jre"]
                          [com.google.code.findbugs/jsr305 "3.0.2"]
-                         [org.slf4j/slf4j-api "2.0.11"]]
+                         [com.google.errorprone/error_prone_annotations "2.23.0"]
+                         [org.slf4j/slf4j-api "2.0.11"]
+                         [org.checkerframework/checker-qual "3.41.0"]]
 
   :test-selectors {:slow :slow
                    :commit (complement :slow)}
@@ -39,8 +41,12 @@
                  [org.clojure/core.logic "1.1.1"]
 
                  ;; reasoners
-                 [io.github.liveontologies/elk-owlapi "0.6.0"]
-                 [net.sourceforge.owlapi/org.semanticweb.hermit "1.4.5.519"]
+                 [io.github.liveontologies/elk-owlapi "0.6.0"
+                  :exclusions [net.sourceforge.owlapi/owlapi-apibinding
+                               net.sourceforge.owlapi/owlapi-api
+                               net.sourceforge.owlapi/owlapi-impl]]
+                 [net.sourceforge.owlapi/org.semanticweb.hermit "1.4.5.519"
+                  :exclusions [net.sourceforge.owlapi/owlapi-distribution]]
                  [net.sourceforge.owlapi/jfact "5.0.3"
                   :exclusions [net.sourceforge.owlapi/owlapi-apibinding]]
 


### PR DESCRIPTION
The [ELK Reasoner](https://github.com/liveontologies/elk-reasoner) and [Hermit](https://github.com/owlcs/hermit-reasoner) dependencies reference OWLAPI 5.1.20 and 5.1.9, rather than the current 5.5.1. Leiningen generally defaults to 5.5.1, and this looks like it works, but a warning is issued. This PR removes their downstream dependencies on OWLAPI artifacts, so that the latest will be used.

Meanwhile, OWLAPI depends on com.github.ben-manes.caffeine/caffeine, which brings in old versions of org.checkerframework/checker-qual and com.google.errorprone/error_prone_annotations. However, OWLAPI also brings in com.google.guava/guava which references newer versions of these same libraries. These are issues for OWLAPI to sort out.